### PR TITLE
fix: look up client by primary key when creating session

### DIFF
--- a/src/session/services/session.service.ts
+++ b/src/session/services/session.service.ts
@@ -142,7 +142,7 @@ export class SessionService {
       );
       const existingClient = await this.knexService
         .db('clients')
-        .where('client_id', createSession.client_id)
+        .where('id', createSession.client_id)
         .first();
 
       if (!existingClient) {


### PR DESCRIPTION
## Summary
- `createNewSession` was querying `clients.client_id` (the FK to `users.id`) to verify the client exists
- The frontend sends `clients.id` (the primary key), so the record was never found and every POST /session returned 400 "Client does not exist"
- Fixed by changing the lookup to `WHERE id = client_id`

## Test plan
- [x] All unit tests pass (`yarn test`)
- [ ] POST /session with a valid `client_id` (primary key) successfully creates the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)