### PR TITLE
fix: make description optional and correct client_id FK on session create

### DIFF
--- a/src/session/services/session.service.ts
+++ b/src/session/services/session.service.ts
@@ -166,7 +166,7 @@ export class SessionService {
       }
 
       const dbSession = {
-        client_id: createSession.client_id,
+        client_id: existingClient.client_id,
         trainer_id: createSession.trainer_id,
         session_type: createSession.session_type,
         start_time: new Date(createSession.start_time),

--- a/src/types/dto/session.dto.ts
+++ b/src/types/dto/session.dto.ts
@@ -82,9 +82,10 @@ export class CreateSessionDto {
   @IsNotEmpty()
   end_time: string;
 
-  @ApiProperty({ example: 'Focus on upper body compound lifts' })
+  @ApiPropertyOptional({ example: 'Focus on upper body compound lifts' })
   @IsString()
-  description: string;
+  @IsOptional()
+  description?: string;
 
   @ApiPropertyOptional({
     example: ['Cupping', 'Hyper volt'],


### PR DESCRIPTION
## Summary
- `description` in `CreateSessionDto` is now optional (was causing 400 on requests without it)
- `createNewSession` now inserts `existingClient.client_id` (the `users.id` FK) instead of `createSession.client_id` (the `clients.id` PK), fixing the `sessions_client_id_fkey` constraint violation

## Test plan
- [ ] Create a session without a `description` field — should succeed
- [ ] Create a session with a valid `client_id` — should no longer return FK constraint error
- [ ] Create a session with an invalid `client_id` — should return "Client does not exist" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)