### PR TITLE
fix: GET /session/client/:clientId always returning empty array

### DIFF
--- a/src/session/services/session.service.ts
+++ b/src/session/services/session.service.ts
@@ -84,7 +84,7 @@ export class SessionService {
           'S.description',
           'S.tools_used',
         )
-        .where('C.id', clientId)
+        .where('S.client_id', clientId)
         .orderBy('S.start_time', 'desc');
 
       return sessionEntities.map((s) => this.toSessionResponse(s));


### PR DESCRIPTION
## Summary
- `getSessionsByClientId` was filtering on `C.id` (the `clients` table primary key) but the `:clientId` route param is `clients.client_id` (= `users.id`), which is also the value stored in `sessions.client_id`
- Changed the WHERE clause from `.where('C.id', clientId)` to `.where('S.client_id', clientId)` to match directly against the value in the sessions table, eliminating the ambiguity

## Test plan
- [ ] Call `GET /session/client/:clientId` with a `client_id` value (the `users.id` FK, not the `clients.id` PK) for a client with known sessions — should now return the session list
- [ ] Verify `POST /session/trainer/:trainerId` (calendar) still returns sessions correctly
- [ ] Verify `POST /session` (create) still works and new sessions appear in both endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)