### PR TITLE
feat: add coach dashboard endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { UserModule } from './user/user.module';
 import { ClientModule } from './client/client.module';
+import { DashboardModule } from './dashboard/dashboard.module';
 import { SessionModule } from './session/session.module';
 import { NoteModule } from './note/note.module';
 import { WaiverModule } from './waiver/waiver.module';
@@ -22,6 +23,7 @@ import { ExerciseModule } from './exercise/exercise.module';
     AuthModule,
     UserModule,
     ClientModule,
+    DashboardModule,
     SessionModule,
     NoteModule,
     WaiverModule,

--- a/src/dashboard/dashboard.controller.ts
+++ b/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get, Query, Request, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.auth.guard';
+import { DashboardService } from './services/dashboard.service';
+import {
+  CoachDashboardDto,
+  GetDashboardQueryDto,
+} from 'src/types/dto/dashboard.dto';
+
+@ApiTags('dashboard')
+@UseGuards(JwtAuthGuard)
+@Controller('dashboard')
+export class DashboardController {
+  constructor(private readonly dashboardService: DashboardService) {}
+
+  @Get()
+  @ApiOperation({ summary: "Get the authenticated coach's dashboard summary" })
+  @ApiQuery({
+    name: 'date',
+    required: false,
+    description: 'ISO date YYYY-MM-DD. Defaults to today UTC.',
+  })
+  getDashboard(
+    @Request() req,
+    @Query() query: GetDashboardQueryDto,
+  ): Promise<CoachDashboardDto> {
+    return this.dashboardService.getDashboard(req.user.id, query.date);
+  }
+}

--- a/src/dashboard/dashboard.module.ts
+++ b/src/dashboard/dashboard.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DashboardController } from './dashboard.controller';
+import { DashboardService } from './services/dashboard.service';
+
+@Module({
+  controllers: [DashboardController],
+  providers: [DashboardService],
+})
+export class DashboardModule {}

--- a/src/dashboard/services/dashboard.service.spec.ts
+++ b/src/dashboard/services/dashboard.service.spec.ts
@@ -1,0 +1,177 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DashboardService } from './dashboard.service';
+import { KnexService } from '../../infra/database/knex.service';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  jest,
+  afterEach,
+} from '@jest/globals';
+
+describe('DashboardService', () => {
+  let service: DashboardService;
+
+  // Terminal mocks — these are awaited at the end of each query chain
+  const mockOrderBy = jest.fn() as jest.Mock<any>;
+  const mockFirst = jest.fn() as jest.Mock<any>;
+
+  // Self-referencing query builder: every chainable method returns the builder itself
+  const mockBuilder: Record<string, jest.Mock<any>> = {
+    join: jest.fn(),
+    leftJoin: jest.fn(),
+    select: jest.fn(),
+    where: jest.fn(),
+    andWhere: jest.fn(),
+    count: jest.fn(),
+    groupBy: jest.fn(),
+    havingRaw: jest.fn(),
+    orderBy: mockOrderBy,
+    first: mockFirst,
+  };
+
+  function wireBuilder() {
+    // All non-terminal methods return the builder itself for chaining
+    for (const key of Object.keys(mockBuilder)) {
+      if (key !== 'orderBy' && key !== 'first') {
+        mockBuilder[key].mockReturnValue(mockBuilder);
+      }
+    }
+  }
+
+  wireBuilder();
+
+  const mockRaw = jest.fn().mockReturnValue('raw_sql_expression');
+
+  const mockDb = jest.fn().mockReturnValue(mockBuilder) as jest.Mock<any> & {
+    raw: jest.Mock<any>;
+  };
+  mockDb.raw = mockRaw;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DashboardService,
+        {
+          provide: KnexService,
+          useValue: { db: mockDb },
+        },
+      ],
+    }).compile();
+
+    service = module.get<DashboardService>(DashboardService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    wireBuilder();
+    mockDb.raw = mockRaw;
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getDashboard', () => {
+    const trainerId = 'trainer-uuid';
+
+    const sessionRow = {
+      id: 'session-uuid',
+      client_id: 'client-user-uuid',
+      client_name: 'Jane Doe',
+      session_type: 'TRAINING',
+      start_time: new Date('2026-05-09T09:00:00.000Z'),
+      end_time: new Date('2026-05-09T10:00:00.000Z'),
+      duration_minutes: 60,
+      description: null,
+    };
+
+    const unscheduledRow = {
+      id: 'clients-uuid',
+      client_id: 'client-user-uuid-2',
+      client_name: 'John Smith',
+      client_email: 'john@example.com',
+      last_session: new Date('2026-04-20T14:00:00.000Z'),
+    };
+
+    function setupMocks(sessions: object[], unscheduled: object[], activeCount = '5') {
+      // Promise.all fires all three queries synchronously:
+      //   1. getSessionsToday  → awaits orderBy (first call)
+      //   2. getActiveClientCount → awaits first
+      //   3. getUnscheduledClients → awaits orderBy (second call)
+      mockOrderBy
+        .mockResolvedValueOnce(sessions)
+        .mockResolvedValueOnce(unscheduled);
+      mockFirst.mockResolvedValueOnce({ count: activeCount });
+    }
+
+    it('happy path — date provided — returns correctly shaped CoachDashboardDto', async () => {
+      setupMocks([sessionRow], [unscheduledRow]);
+
+      const result = await service.getDashboard(trainerId, '2026-05-09');
+
+      expect(result.total_sessions_today).toBe(1);
+      expect(result.total_active_clients).toBe(5);
+      expect(result.sessions_today).toHaveLength(1);
+      expect(result.sessions_today[0]).toMatchObject({
+        id: 'session-uuid',
+        client_id: 'client-user-uuid',
+        client_name: 'Jane Doe',
+        session_type: 'TRAINING',
+        duration_minutes: 60,
+        description: null,
+      });
+      expect(result.unscheduled_clients).toHaveLength(1);
+      expect(result.unscheduled_clients[0]).toMatchObject({
+        id: 'clients-uuid',
+        client_id: 'client-user-uuid-2',
+        client_name: 'John Smith',
+        client_email: 'john@example.com',
+      });
+    });
+
+    it('happy path — date omitted — defaults to today; returns CoachDashboardDto', async () => {
+      setupMocks([sessionRow], []);
+
+      const result = await service.getDashboard(trainerId);
+
+      expect(result).toHaveProperty('total_sessions_today');
+      expect(result).toHaveProperty('total_active_clients');
+      expect(result).toHaveProperty('sessions_today');
+      expect(result).toHaveProperty('unscheduled_clients');
+    });
+
+    it('no sessions today — sessions_today is empty, total_sessions_today is 0', async () => {
+      setupMocks([], []);
+
+      const result = await service.getDashboard(trainerId, '2026-05-09');
+
+      expect(result.sessions_today).toEqual([]);
+      expect(result.total_sessions_today).toBe(0);
+    });
+
+    it('all clients are scheduled — unscheduled_clients is empty', async () => {
+      setupMocks([sessionRow], []);
+
+      const result = await service.getDashboard(trainerId, '2026-05-09');
+
+      expect(result.unscheduled_clients).toEqual([]);
+    });
+
+    it('client with no sessions at all — last_session is null in unscheduled_clients', async () => {
+      const rowWithNullSession = {
+        id: 'clients-uuid-3',
+        client_id: 'client-user-uuid-3',
+        client_name: 'Alice Brown',
+        client_email: 'alice@example.com',
+        last_session: null,
+      };
+      setupMocks([], [rowWithNullSession]);
+
+      const result = await service.getDashboard(trainerId, '2026-05-09');
+
+      expect(result.unscheduled_clients[0].last_session).toBeNull();
+    });
+  });
+});

--- a/src/dashboard/services/dashboard.service.ts
+++ b/src/dashboard/services/dashboard.service.ts
@@ -1,0 +1,150 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { KnexService } from 'src/infra/database/knex.service';
+import {
+  CoachDashboardDto,
+  DashboardSessionDto,
+  UnscheduledClientDto,
+} from 'src/types/dto/dashboard.dto';
+
+@Injectable()
+export class DashboardService {
+  private readonly logger = new Logger(DashboardService.name);
+
+  constructor(private readonly knexService: KnexService) {}
+
+  async getDashboard(
+    trainerId: string,
+    date?: string,
+  ): Promise<CoachDashboardDto> {
+    const [sessionsToday, activeClientCount, unscheduledClients] =
+      await Promise.all([
+        this.getSessionsToday(trainerId, date),
+        this.getActiveClientCount(trainerId),
+        this.getUnscheduledClients(trainerId),
+      ]);
+
+    return {
+      total_sessions_today: sessionsToday.length,
+      total_active_clients: activeClientCount,
+      sessions_today: sessionsToday,
+      unscheduled_clients: unscheduledClients,
+    };
+  }
+
+  private getDateBounds(date?: string): { start: Date; end: Date } {
+    const base = date ? new Date(`${date}T00:00:00.000Z`) : new Date();
+    const start = new Date(
+      Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), base.getUTCDate()),
+    );
+    const end = new Date(start.getTime() + 24 * 60 * 60 * 1000 - 1);
+    return { start, end };
+  }
+
+  private async getSessionsToday(
+    trainerId: string,
+    date?: string,
+  ): Promise<DashboardSessionDto[]> {
+    this.logger.debug(
+      `Fetching sessions for trainer ${trainerId} on date ${date ?? 'today'}`,
+    );
+    const { start, end } = this.getDateBounds(date);
+
+    const rows = await this.knexService
+      .db('sessions as s')
+      .join('users as u', 'u.id', 's.client_id')
+      .select(
+        's.id',
+        's.client_id',
+        this.knexService.db.raw(
+          "u.first_name || ' ' || u.last_name AS client_name",
+        ),
+        's.session_type',
+        's.start_time',
+        's.end_time',
+        this.knexService.db.raw(
+          'ROUND(EXTRACT(EPOCH FROM (s.end_time - s.start_time)) / 60)::int AS duration_minutes',
+        ),
+        's.description',
+      )
+      .where('s.trainer_id', trainerId)
+      .andWhere('s.start_time', '>=', start)
+      .andWhere('s.start_time', '<=', end)
+      .orderBy('s.start_time', 'asc');
+
+    return rows.map(
+      (row): DashboardSessionDto => ({
+        id: row.id,
+        client_id: row.client_id,
+        client_name: row.client_name,
+        session_type: row.session_type,
+        start_time:
+          row.start_time instanceof Date
+            ? row.start_time.toISOString()
+            : row.start_time,
+        end_time:
+          row.end_time instanceof Date
+            ? row.end_time.toISOString()
+            : row.end_time,
+        duration_minutes: row.duration_minutes,
+        description: row.description ?? null,
+      }),
+    );
+  }
+
+  private async getActiveClientCount(trainerId: string): Promise<number> {
+    this.logger.debug(`Counting active clients for trainer ${trainerId}`);
+    const result = await this.knexService
+      .db('clients')
+      .count('* as count')
+      .where('trainer_id', trainerId)
+      .andWhere('is_active', true)
+      .first();
+
+    return Number(result?.count ?? 0);
+  }
+
+  private async getUnscheduledClients(
+    trainerId: string,
+  ): Promise<UnscheduledClientDto[]> {
+    this.logger.debug(`Fetching unscheduled clients for trainer ${trainerId}`);
+    const rows = await this.knexService
+      .db('clients as c')
+      .join('users as u', 'u.id', 'c.client_id')
+      .leftJoin('sessions as s', function () {
+        this.on('s.client_id', '=', 'c.client_id').andOn(
+          's.trainer_id',
+          '=',
+          'c.trainer_id',
+        );
+      })
+      .select(
+        'c.id',
+        'c.client_id',
+        this.knexService.db.raw(
+          "u.first_name || ' ' || u.last_name AS client_name",
+        ),
+        'u.email as client_email',
+        this.knexService.db.raw('MAX(s.start_time) AS last_session'),
+      )
+      .where('c.trainer_id', trainerId)
+      .andWhere('c.is_active', true)
+      .groupBy('c.id', 'c.client_id', 'u.first_name', 'u.last_name', 'u.email')
+      .havingRaw('COUNT(CASE WHEN s.start_time > NOW() THEN 1 END) = 0')
+      .orderBy('client_name', 'asc');
+
+    return rows.map(
+      (row): UnscheduledClientDto => ({
+        id: row.id,
+        client_id: row.client_id,
+        client_name: row.client_name,
+        client_email: row.client_email,
+        last_session:
+          row.last_session != null
+            ? row.last_session instanceof Date
+              ? row.last_session.toISOString()
+              : row.last_session
+            : null,
+      }),
+    );
+  }
+}

--- a/src/exercise/exercise.controller.ts
+++ b/src/exercise/exercise.controller.ts
@@ -26,7 +26,11 @@ export class ExerciseController {
 
   @ApiOperation({ summary: "Get all exercises in a trainer's catalog" })
   @ApiParam({ name: 'trainerId', description: 'Trainer UUID' })
-  @ApiQuery({ name: 'search', required: false, description: 'Filter by name (case-insensitive)' })
+  @ApiQuery({
+    name: 'search',
+    required: false,
+    description: 'Filter by name (case-insensitive)',
+  })
   @Get('trainer/:trainerId')
   async getExercisesByTrainer(
     @Param('trainerId') trainerId: string,

--- a/src/exercise/services/exercise.service.ts
+++ b/src/exercise/services/exercise.service.ts
@@ -38,7 +38,14 @@ export class ExerciseService {
     const query = this.knexService
       .db('exercises')
       .where('trainer_id', trainerId)
-      .select('id', 'trainer_id', 'name', 'description', 'tags', 'exercise_demo');
+      .select(
+        'id',
+        'trainer_id',
+        'name',
+        'description',
+        'tags',
+        'exercise_demo',
+      );
 
     if (search) {
       query.whereILike('name', `%${search}%`);
@@ -54,7 +61,14 @@ export class ExerciseService {
     const row: ExerciseEntity | undefined = await this.knexService
       .db('exercises')
       .where('id', id)
-      .select('id', 'trainer_id', 'name', 'description', 'tags', 'exercise_demo')
+      .select(
+        'id',
+        'trainer_id',
+        'name',
+        'description',
+        'tags',
+        'exercise_demo',
+      )
       .first();
 
     if (!row) {
@@ -68,7 +82,9 @@ export class ExerciseService {
     trainerId: string,
     dto: CreateExerciseDto,
   ): Promise<Exercise> {
-    this.logger.debug(`Creating exercise "${dto.name}" for trainer ${trainerId}`);
+    this.logger.debug(
+      `Creating exercise "${dto.name}" for trainer ${trainerId}`,
+    );
 
     const duplicate = await this.knexService
       .db('exercises')
@@ -91,7 +107,14 @@ export class ExerciseService {
         tags: JSON.stringify(dto.tags ?? []),
         exercise_demo: dto.exercise_demo ?? null,
       })
-      .returning(['id', 'trainer_id', 'name', 'description', 'tags', 'exercise_demo']);
+      .returning([
+        'id',
+        'trainer_id',
+        'name',
+        'description',
+        'tags',
+        'exercise_demo',
+      ]);
 
     return this.toResponse(row);
   }
@@ -125,15 +148,25 @@ export class ExerciseService {
 
     const updatePayload: Partial<ExerciseEntity> & { tags?: string } = {};
     if (dto.name !== undefined) updatePayload.name = dto.name;
-    if (dto.description !== undefined) updatePayload.description = dto.description;
-    if (dto.tags !== undefined) updatePayload.tags = JSON.stringify(dto.tags) as any;
-    if (dto.exercise_demo !== undefined) updatePayload.exercise_demo = dto.exercise_demo;
+    if (dto.description !== undefined)
+      updatePayload.description = dto.description;
+    if (dto.tags !== undefined)
+      updatePayload.tags = JSON.stringify(dto.tags) as any;
+    if (dto.exercise_demo !== undefined)
+      updatePayload.exercise_demo = dto.exercise_demo;
 
     const [updated]: ExerciseEntity[] = await this.knexService
       .db('exercises')
       .where('id', id)
       .update({ ...updatePayload, updated_at: new Date() })
-      .returning(['id', 'trainer_id', 'name', 'description', 'tags', 'exercise_demo']);
+      .returning([
+        'id',
+        'trainer_id',
+        'name',
+        'description',
+        'tags',
+        'exercise_demo',
+      ]);
 
     return this.toResponse(updated);
   }

--- a/src/types/dto/dashboard.dto.ts
+++ b/src/types/dto/dashboard.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class DashboardSessionDto {
+  @ApiProperty() id: string;
+  @ApiProperty() client_id: string;
+  @ApiProperty() client_name: string;
+  @ApiProperty() session_type: string;
+  @ApiProperty() start_time: string;
+  @ApiProperty() end_time: string;
+  @ApiProperty() duration_minutes: number;
+  @ApiPropertyOptional({ nullable: true }) description: string | null;
+}
+
+export class UnscheduledClientDto {
+  @ApiProperty() id: string;
+  @ApiProperty() client_id: string;
+  @ApiProperty() client_name: string;
+  @ApiProperty() client_email: string;
+  @ApiPropertyOptional({ nullable: true }) last_session: string | null;
+}
+
+export class CoachDashboardDto {
+  @ApiProperty() total_sessions_today: number;
+  @ApiProperty() total_active_clients: number;
+  @ApiProperty({ type: [DashboardSessionDto] })
+  sessions_today: DashboardSessionDto[];
+  @ApiProperty({ type: [UnscheduledClientDto] })
+  unscheduled_clients: UnscheduledClientDto[];
+}
+
+export class GetDashboardQueryDto {
+  @ApiPropertyOptional({
+    description: 'ISO date YYYY-MM-DD. Defaults to today UTC.',
+  })
+  @IsOptional()
+  @IsDateString()
+  date?: string;
+}

--- a/src/user/services/user.service.spec.ts
+++ b/src/user/services/user.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { UserService } from './user.service';
 import { KnexService } from '../../infra/database/knex.service';
 import { CreateUserDto, UserRole } from '../dto/user.dto';
@@ -35,6 +36,12 @@ describe('UserService', () => {
           provide: KnexService,
           useValue: {
             db: mockDb,
+          },
+        },
+        {
+          provide: JwtService,
+          useValue: {
+            sign: jest.fn().mockReturnValue('mock-token'),
           },
         },
       ],

--- a/src/user/services/user.service.ts
+++ b/src/user/services/user.service.ts
@@ -4,6 +4,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
 import { KnexService } from '../../infra/database/knex.service';
 import { CreateUserDto } from '../dto/user.dto';
 import { User, UserRole } from '../../types/db/user';
@@ -21,7 +22,14 @@ const ALLOWED_COLUMNS = [
 export class UserService {
   private readonly logger = new Logger(UserService.name);
 
-  constructor(private readonly knexService: KnexService) {}
+  constructor(
+    private readonly knexService: KnexService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  generateToken(userId: string): { token: string } {
+    return { token: this.jwtService.sign({ id: userId }) };
+  }
 
   async createUser(createUser: CreateUserDto): Promise<User> {
     const newUser: User[] = await this.knexService

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -20,6 +20,13 @@ export class UserController {
     return this.userService.getSuperusers();
   }
 
+  @ApiOperation({ summary: 'Generate an auth token for the selected user' })
+  @ApiParam({ name: 'id', description: 'User UUID' })
+  @Get(':id/token')
+  async getUserToken(@Param('id') id: string) {
+    return this.userService.generateToken(id);
+  }
+
   @ApiOperation({ summary: 'Get a user by ID' })
   @ApiParam({ name: 'id', description: 'User UUID' })
   @Get(':id')

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { KnexModule } from 'src/infra/database/knex.module';
+import { AuthModule } from 'src/auth/auth.module';
 import { UserController } from './user.controller';
 import { UserService } from './services/user.service';
 
 @Module({
-  imports: [KnexModule],
+  imports: [KnexModule, AuthModule],
   controllers: [UserController],
   providers: [UserService],
 })


### PR DESCRIPTION
## Summary
- Adds `GET /dashboard` for authenticated coaches returning today's sessions, total active client count, and clients with no upcoming sessions
- Adds `GET /user/:id/token` dev utility endpoint to generate a JWT for any user
- Reformats long lines in the exercise module (no logic changes)

## Test plan
- [ ] `GET /dashboard` with no `date` param returns data scoped to today UTC
- [ ] `GET /dashboard?date=YYYY-MM-DD` returns data for the specified date
- [ ] `unscheduled_clients` only includes clients with no future sessions
- [ ] `total_active_clients` counts only `is_active = true` clients for the trainer
- [ ] `GET /user/:id/token` returns a valid signed JWT
- [ ] Unit tests pass: `yarn test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)