### PR TITLE
feat: add program builder module

### DIFF
--- a/migrations/202605240001_create_programs.js
+++ b/migrations/202605240001_create_programs.js
@@ -1,0 +1,24 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable('programs', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table.uuid('trainer_id').notNullable().references('id').inTable('users');
+    table.uuid('client_id').notNullable().references('id').inTable('clients');
+    table.string('name').notNullable();
+    table.text('description').nullable();
+    table.string('status').notNullable().defaultTo('DRAFT');
+    table.text('notes').nullable();
+    table.timestamps(true, true);
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('programs');
+};

--- a/migrations/202605240002_create_program_exercises.js
+++ b/migrations/202605240002_create_program_exercises.js
@@ -1,0 +1,33 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.createTable('program_exercises', (table) => {
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'));
+    table
+      .uuid('program_id')
+      .notNullable()
+      .references('id')
+      .inTable('programs')
+      .onDelete('CASCADE');
+    table
+      .uuid('exercise_id')
+      .notNullable()
+      .references('id')
+      .inTable('exercises');
+    table.integer('order_index').notNullable().defaultTo(0);
+    table.integer('sets').nullable();
+    table.string('reps').nullable();
+    table.integer('duration_seconds').nullable();
+    table.text('notes').nullable();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.dropTableIfExists('program_exercises');
+};

--- a/migrations/202605270001_add_tags_to_programs.js
+++ b/migrations/202605270001_add_tags_to_programs.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema.alterTable('programs', (table) => {
+    table.jsonb('tags').notNullable().defaultTo('[]');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema.alterTable('programs', (table) => {
+    table.dropColumn('tags');
+  });
+};

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "knex": "^3.1.0",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
+    "pdfkit": "^0.18.0",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
@@ -50,6 +51,7 @@
     "@types/jest": "^30.0.0",
     "@types/multer": "^2.0.0",
     "@types/node": "^24.1.0",
+    "@types/pdfkit": "^0.17.6",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { SessionModule } from './session/session.module';
 import { NoteModule } from './note/note.module';
 import { WaiverModule } from './waiver/waiver.module';
 import { ExerciseModule } from './exercise/exercise.module';
+import { ProgramModule } from './program/program.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { ExerciseModule } from './exercise/exercise.module';
     NoteModule,
     WaiverModule,
     ExerciseModule,
+    ProgramModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/program/program.controller.ts
+++ b/src/program/program.controller.ts
@@ -1,0 +1,143 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Request,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import type { Response } from 'express';
+import { JwtAuthGuard } from 'src/auth/guards/jwt.auth.guard';
+import { ProgramService } from './services/program.service';
+import {
+  AddExerciseDto,
+  CreateProgramDto,
+  GetProgramsQueryDto,
+  ProgramDto,
+  ProgramExerciseDto,
+  ProgramSummaryDto,
+  ReorderExercisesDto,
+  UpdateProgramDto,
+  UpdateProgramExerciseDto,
+} from 'src/types/dto/program.dto';
+
+@ApiTags('Programs')
+@UseGuards(JwtAuthGuard)
+@Controller('programs')
+export class ProgramController {
+  constructor(private readonly programService: ProgramService) {}
+
+  @ApiOperation({ summary: 'Get all programs for the authenticated coach' })
+  @Get()
+  getPrograms(
+    @Query() query: GetProgramsQueryDto,
+    @Request() req,
+  ): Promise<ProgramSummaryDto[]> {
+    return this.programService.getPrograms(req.user.id, query.client_id);
+  }
+
+  @ApiOperation({ summary: 'Create a new program' })
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  createProgram(
+    @Body() dto: CreateProgramDto,
+    @Request() req,
+  ): Promise<ProgramDto> {
+    return this.programService.createProgram(req.user.id, dto);
+  }
+
+  @ApiOperation({ summary: 'Get a program by ID' })
+  @Get(':id')
+  getProgramById(@Param('id') id: string, @Request() req): Promise<ProgramDto> {
+    return this.programService.getProgramById(req.user.id, id);
+  }
+
+  @ApiOperation({ summary: 'Update program metadata' })
+  @Patch(':id')
+  updateProgram(
+    @Param('id') id: string,
+    @Body() dto: UpdateProgramDto,
+    @Request() req,
+  ): Promise<ProgramDto> {
+    return this.programService.updateProgram(req.user.id, id, dto);
+  }
+
+  @ApiOperation({ summary: 'Delete a program' })
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  deleteProgram(@Param('id') id: string, @Request() req): Promise<void> {
+    return this.programService.deleteProgram(req.user.id, id);
+  }
+
+  @ApiOperation({ summary: 'Add an exercise to a program' })
+  @Post(':id/exercises')
+  @HttpCode(HttpStatus.CREATED)
+  addExercise(
+    @Param('id') id: string,
+    @Body() dto: AddExerciseDto,
+    @Request() req,
+  ): Promise<ProgramExerciseDto> {
+    return this.programService.addExercise(req.user.id, id, dto);
+  }
+
+  @ApiOperation({ summary: 'Reorder exercises in a program' })
+  @Patch(':id/exercises/reorder')
+  reorderExercises(
+    @Param('id') id: string,
+    @Body() dto: ReorderExercisesDto,
+    @Request() req,
+  ): Promise<ProgramDto> {
+    return this.programService.reorderExercises(req.user.id, id, dto);
+  }
+
+  @ApiOperation({ summary: 'Update a program exercise slot' })
+  @Patch(':id/exercises/:programExerciseId')
+  updateProgramExercise(
+    @Param('id') id: string,
+    @Param('programExerciseId') peId: string,
+    @Body() dto: UpdateProgramExerciseDto,
+    @Request() req,
+  ): Promise<ProgramExerciseDto> {
+    return this.programService.updateProgramExercise(
+      req.user.id,
+      id,
+      peId,
+      dto,
+    );
+  }
+
+  @ApiOperation({ summary: 'Remove an exercise from a program' })
+  @Delete(':id/exercises/:programExerciseId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  removeProgramExercise(
+    @Param('id') id: string,
+    @Param('programExerciseId') peId: string,
+    @Request() req,
+  ): Promise<void> {
+    return this.programService.removeProgramExercise(req.user.id, id, peId);
+  }
+
+  @ApiOperation({ summary: 'Export a program as PDF' })
+  @Get(':id/export')
+  async exportProgram(
+    @Param('id') id: string,
+    @Request() req,
+    @Res() res: Response,
+  ): Promise<void> {
+    const buffer = await this.programService.exportProgram(req.user.id, id);
+    res.set({
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="program-${id}.pdf"`,
+      'Content-Length': buffer.length,
+    });
+    res.end(buffer);
+  }
+}

--- a/src/program/program.module.ts
+++ b/src/program/program.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ProgramController } from './program.controller';
+import { ProgramService } from './services/program.service';
+
+@Module({
+  controllers: [ProgramController],
+  providers: [ProgramService],
+})
+export class ProgramModule {}

--- a/src/program/services/program.service.spec.ts
+++ b/src/program/services/program.service.spec.ts
@@ -1,0 +1,588 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { ProgramService } from './program.service';
+import { KnexService } from '../../infra/database/knex.service';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  jest,
+  afterEach,
+} from '@jest/globals';
+
+describe('ProgramService', () => {
+  let service: ProgramService;
+
+  const mockDb = jest.fn() as jest.Mock<any>;
+  (mockDb as any).raw = jest.fn((val: string) => val);
+
+  const trainerId = 'trainer-uuid';
+  const clientId = 'client-uuid';
+  const programId = 'program-uuid';
+  const exerciseId = 'exercise-uuid';
+  const peId = 'pe-uuid';
+
+  const programRow = {
+    id: programId,
+    trainer_id: trainerId,
+    client_id: clientId,
+    name: 'Phase 1',
+    description: 'Foundation block',
+    status: 'DRAFT',
+    tags: ['Strength', 'Lower Body'],
+    notes: null,
+    created_at: new Date('2026-05-24T10:00:00Z'),
+    updated_at: new Date('2026-05-24T10:00:00Z'),
+  };
+
+  const exerciseRow = {
+    id: exerciseId,
+    trainer_id: trainerId,
+    name: 'Squat',
+    description: null,
+    tags: ['legs'],
+    exercise_demo: null,
+  };
+
+  const peRow = {
+    id: peId,
+    program_id: programId,
+    exercise_id: exerciseId,
+    order_index: 0,
+    sets: 3,
+    reps: '8-10',
+    duration_seconds: null,
+    notes: null,
+  };
+
+  const programWithClientName = {
+    ...programRow,
+    client_name: 'Jane Doe',
+  };
+
+  /**
+   * Creates a fully chainable Knex query builder mock.
+   * - Every chain method (join, where, select, etc.) returns `this`
+   * - `.first()` resolves to `firstResolve`
+   * - `.del()` resolves to 1
+   * - `.returning()` resolves to `returningResolve`
+   * - If `selfResolve` is set, `await builder` resolves to that value
+   */
+  function makeBuilder({
+    firstResolve = undefined as any,
+    selfResolve = undefined as any,
+    returningResolve = undefined as any,
+  } = {}) {
+    const b: Record<string, any> = {};
+    const self = () => b;
+
+    [
+      'join', 'leftJoin', 'select', 'where', 'whereILike', 'whereNot',
+      'groupBy', 'orderBy', 'max', 'insert', 'update',
+    ].forEach((m) => {
+      b[m] = jest.fn(self);
+    });
+
+    b.first = jest.fn().mockResolvedValue(firstResolve);
+    b.del = jest.fn().mockResolvedValue(1);
+    b.returning = jest.fn().mockResolvedValue(returningResolve);
+
+    if (selfResolve !== undefined) {
+      b.then = (resolve: any, reject: any) =>
+        Promise.resolve(selfResolve).then(resolve, reject);
+      b.catch = (onRejected: any) =>
+        Promise.resolve(selfResolve).catch(onRejected);
+    }
+
+    return b;
+  }
+
+  /** Creates the two builders always needed for buildProgramResponse */
+  function buildProgramBuilders(exercises: any[] = [], programOverride = programWithClientName) {
+    const programBuilder = makeBuilder({ firstResolve: programOverride });
+    const exercisesBuilder = makeBuilder({ selfResolve: exercises });
+    return [programBuilder, exercisesBuilder] as const;
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProgramService,
+        { provide: KnexService, useValue: { db: mockDb } },
+      ],
+    }).compile();
+
+    service = module.get<ProgramService>(ProgramService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPrograms
+  // ---------------------------------------------------------------------------
+  describe('getPrograms', () => {
+    it('should return program summaries', async () => {
+      const summaryRow = { ...programRow, client_name: 'Jane Doe', exercise_count: 2 };
+      const listBuilder = makeBuilder({ selfResolve: [summaryRow] });
+      mockDb.mockReturnValueOnce(listBuilder);
+
+      const result = await service.getPrograms(trainerId);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].client_name).toBe('Jane Doe');
+      expect(result[0].exercise_count).toBe(2);
+      expect(result[0].tags).toEqual(['Strength', 'Lower Body']);
+    });
+
+    it('should filter by client_id when provided', async () => {
+      const listBuilder = makeBuilder({ selfResolve: [] });
+      mockDb.mockReturnValueOnce(listBuilder);
+
+      const result = await service.getPrograms(trainerId, clientId);
+
+      expect(result).toHaveLength(0);
+      expect(listBuilder.where).toHaveBeenCalledWith('p.client_id', clientId);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // createProgram
+  // ---------------------------------------------------------------------------
+  describe('createProgram', () => {
+    it('should create a program and return the full program response', async () => {
+      const clientBuilder = makeBuilder({ firstResolve: { id: clientId, trainer_id: trainerId } });
+      const insertBuilder = makeBuilder({ returningResolve: [{ id: programId }] });
+      const [programBuilder, exercisesBuilder] = buildProgramBuilders();
+
+      mockDb
+        .mockReturnValueOnce(clientBuilder)
+        .mockReturnValueOnce(insertBuilder)
+        .mockReturnValueOnce(programBuilder)
+        .mockReturnValueOnce(exercisesBuilder);
+
+      const result = await service.createProgram(trainerId, {
+        client_id: clientId,
+        name: 'Phase 1',
+      });
+
+      expect(result.id).toBe(programId);
+      expect(result.exercises).toEqual([]);
+      expect(insertBuilder.insert).toHaveBeenCalled();
+    });
+
+    it('should pass tags to the insert when provided', async () => {
+      const clientBuilder = makeBuilder({ firstResolve: { id: clientId, trainer_id: trainerId } });
+      const insertBuilder = makeBuilder({ returningResolve: [{ id: programId }] });
+      const [programBuilder, exercisesBuilder] = buildProgramBuilders(
+        [],
+        { ...programWithClientName, tags: ['Mobility'] },
+      );
+
+      mockDb
+        .mockReturnValueOnce(clientBuilder)
+        .mockReturnValueOnce(insertBuilder)
+        .mockReturnValueOnce(programBuilder)
+        .mockReturnValueOnce(exercisesBuilder);
+
+      await service.createProgram(trainerId, { client_id: clientId, name: 'Phase 1', tags: ['Mobility'] });
+
+      const insertCall = insertBuilder.insert.mock.calls[0][0] as Record<string, unknown>;
+      expect(insertCall.tags).toBe(JSON.stringify(['Mobility']));
+    });
+
+    it('should throw ForbiddenException when client does not belong to trainer', async () => {
+      const clientBuilder = makeBuilder({ firstResolve: undefined });
+      mockDb.mockReturnValueOnce(clientBuilder);
+
+      await expect(
+        service.createProgram(trainerId, { client_id: 'other-client', name: 'Phase 1' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getProgramById
+  // ---------------------------------------------------------------------------
+  describe('getProgramById', () => {
+    it('should return a program by ID', async () => {
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const [programBuilder, exercisesBuilder] = buildProgramBuilders();
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(programBuilder)
+        .mockReturnValueOnce(exercisesBuilder);
+
+      const result = await service.getProgramById(trainerId, programId);
+
+      expect(result.id).toBe(programId);
+    });
+
+    it('should throw NotFoundException when program not found', async () => {
+      mockDb.mockReturnValueOnce(makeBuilder({ firstResolve: undefined }));
+
+      await expect(service.getProgramById(trainerId, 'missing')).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when program belongs to another trainer', async () => {
+      mockDb.mockReturnValueOnce(
+        makeBuilder({ firstResolve: { ...programRow, trainer_id: 'other-trainer' } }),
+      );
+
+      await expect(service.getProgramById(trainerId, programId)).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateProgram
+  // ---------------------------------------------------------------------------
+  describe('updateProgram', () => {
+    it('should update program metadata and return updated program', async () => {
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const updateBuilder = makeBuilder({ selfResolve: 1 });
+      const [programBuilder, exercisesBuilder] = buildProgramBuilders();
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(updateBuilder)
+        .mockReturnValueOnce(programBuilder)
+        .mockReturnValueOnce(exercisesBuilder);
+
+      const result = await service.updateProgram(trainerId, programId, { name: 'Updated' });
+
+      expect(result.id).toBe(programId);
+      expect(updateBuilder.update).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException when program is COMPLETE', async () => {
+      mockDb.mockReturnValueOnce(
+        makeBuilder({ firstResolve: { ...programRow, status: 'COMPLETE' } }),
+      );
+
+      await expect(
+        service.updateProgram(trainerId, programId, { name: 'New' }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw BadRequestException for invalid status transition DRAFT → COMPLETE', async () => {
+      mockDb.mockReturnValueOnce(makeBuilder({ firstResolve: programRow }));
+
+      await expect(
+        service.updateProgram(trainerId, programId, { status: 'COMPLETE' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should allow valid status transition DRAFT → READY', async () => {
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const updateBuilder = makeBuilder({ selfResolve: 1 });
+      const [programBuilder, exercisesBuilder] = buildProgramBuilders(
+        [],
+        { ...programWithClientName, status: 'READY' },
+      );
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(updateBuilder)
+        .mockReturnValueOnce(programBuilder)
+        .mockReturnValueOnce(exercisesBuilder);
+
+      const result = await service.updateProgram(trainerId, programId, { status: 'READY' });
+
+      expect(result.status).toBe('READY');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // deleteProgram
+  // ---------------------------------------------------------------------------
+  describe('deleteProgram', () => {
+    it('should delete the program', async () => {
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const delBuilder = makeBuilder();
+
+      mockDb.mockReturnValueOnce(findBuilder).mockReturnValueOnce(delBuilder);
+
+      await service.deleteProgram(trainerId, programId);
+
+      expect(delBuilder.del).toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when program not found', async () => {
+      mockDb.mockReturnValueOnce(makeBuilder({ firstResolve: undefined }));
+
+      await expect(service.deleteProgram(trainerId, 'missing')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // addExercise
+  // ---------------------------------------------------------------------------
+  describe('addExercise', () => {
+    it('should add an exercise at order_index 0 when program is empty', async () => {
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const exerciseFindBuilder = makeBuilder({ firstResolve: exerciseRow });
+      const maxBuilder = makeBuilder({ firstResolve: { max_index: null } });
+      const insertBuilder = makeBuilder({ returningResolve: [peRow] });
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(exerciseFindBuilder)
+        .mockReturnValueOnce(maxBuilder)
+        .mockReturnValueOnce(insertBuilder);
+
+      const result = await service.addExercise(trainerId, programId, {
+        exercise_id: exerciseId,
+        sets: 3,
+        reps: '8-10',
+      });
+
+      expect(result.exercise_id).toBe(exerciseId);
+      expect(result.order_index).toBe(0);
+    });
+
+    it('should assign order_index MAX+1 when exercises already exist', async () => {
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const exerciseFindBuilder = makeBuilder({ firstResolve: exerciseRow });
+      const maxBuilder = makeBuilder({ firstResolve: { max_index: 2 } });
+      const insertBuilder = makeBuilder({ returningResolve: [{ ...peRow, order_index: 3 }] });
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(exerciseFindBuilder)
+        .mockReturnValueOnce(maxBuilder)
+        .mockReturnValueOnce(insertBuilder);
+
+      const result = await service.addExercise(trainerId, programId, { exercise_id: exerciseId });
+
+      expect(result.order_index).toBe(3);
+    });
+
+    it('should throw ForbiddenException when program is COMPLETE', async () => {
+      mockDb.mockReturnValueOnce(
+        makeBuilder({ firstResolve: { ...programRow, status: 'COMPLETE' } }),
+      );
+
+      await expect(
+        service.addExercise(trainerId, programId, { exercise_id: exerciseId }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException when exercise not found', async () => {
+      mockDb
+        .mockReturnValueOnce(makeBuilder({ firstResolve: programRow }))
+        .mockReturnValueOnce(makeBuilder({ firstResolve: undefined }));
+
+      await expect(
+        service.addExercise(trainerId, programId, { exercise_id: 'missing' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when exercise belongs to another trainer', async () => {
+      mockDb
+        .mockReturnValueOnce(makeBuilder({ firstResolve: programRow }))
+        .mockReturnValueOnce(
+          makeBuilder({ firstResolve: { ...exerciseRow, trainer_id: 'other-trainer' } }),
+        );
+
+      await expect(
+        service.addExercise(trainerId, programId, { exercise_id: exerciseId }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // updateProgramExercise
+  // ---------------------------------------------------------------------------
+  describe('updateProgramExercise', () => {
+    it('should update and return the exercise slot', async () => {
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const slotBuilder = makeBuilder({ firstResolve: peRow });
+      const updateBuilder = makeBuilder({ returningResolve: [{ ...peRow, reps: '10-12' }] });
+      const exerciseLookupBuilder = makeBuilder({
+        firstResolve: { name: 'Squat', exercise_demo: null, tags: ['legs'] },
+      });
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(slotBuilder)
+        .mockReturnValueOnce(updateBuilder)
+        .mockReturnValueOnce(exerciseLookupBuilder);
+
+      const result = await service.updateProgramExercise(
+        trainerId, programId, peId, { reps: '10-12' },
+      );
+
+      expect(result.reps).toBe('10-12');
+      expect(result.exercise_name).toBe('Squat');
+    });
+
+    it('should throw ForbiddenException when program is COMPLETE', async () => {
+      mockDb.mockReturnValueOnce(
+        makeBuilder({ firstResolve: { ...programRow, status: 'COMPLETE' } }),
+      );
+
+      await expect(
+        service.updateProgramExercise(trainerId, programId, peId, { sets: 4 }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException when exercise slot not found in program', async () => {
+      mockDb
+        .mockReturnValueOnce(makeBuilder({ firstResolve: programRow }))
+        .mockReturnValueOnce(makeBuilder({ firstResolve: undefined }));
+
+      await expect(
+        service.updateProgramExercise(trainerId, programId, 'missing-pe', { sets: 4 }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // removeProgramExercise
+  // ---------------------------------------------------------------------------
+  describe('removeProgramExercise', () => {
+    it('should delete the slot and re-index remaining exercises', async () => {
+      const remaining = [{ id: 'pe-b' }, { id: 'pe-c' }];
+
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const slotBuilder = makeBuilder({ firstResolve: peRow });
+      const delBuilder = makeBuilder();
+      const remainingBuilder = makeBuilder({ selfResolve: remaining });
+      const updateB1 = makeBuilder({ selfResolve: 1 });
+      const updateB2 = makeBuilder({ selfResolve: 1 });
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(slotBuilder)
+        .mockReturnValueOnce(delBuilder)
+        .mockReturnValueOnce(remainingBuilder)
+        .mockReturnValueOnce(updateB1)
+        .mockReturnValueOnce(updateB2);
+
+      await service.removeProgramExercise(trainerId, programId, peId);
+
+      expect(delBuilder.del).toHaveBeenCalled();
+      expect(updateB1.update).toHaveBeenCalledWith({ order_index: 0 });
+      expect(updateB2.update).toHaveBeenCalledWith({ order_index: 1 });
+    });
+
+    it('should throw ForbiddenException when program is COMPLETE', async () => {
+      mockDb.mockReturnValueOnce(
+        makeBuilder({ firstResolve: { ...programRow, status: 'COMPLETE' } }),
+      );
+
+      await expect(
+        service.removeProgramExercise(trainerId, programId, peId),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw NotFoundException when slot not found', async () => {
+      mockDb
+        .mockReturnValueOnce(makeBuilder({ firstResolve: programRow }))
+        .mockReturnValueOnce(makeBuilder({ firstResolve: undefined }));
+
+      await expect(
+        service.removeProgramExercise(trainerId, programId, 'missing-pe'),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // reorderExercises
+  // ---------------------------------------------------------------------------
+  describe('reorderExercises', () => {
+    it('should reorder and return the updated program', async () => {
+      const existingSlots = [{ id: 'pe-a' }, { id: 'pe-b' }];
+
+      const findBuilder = makeBuilder({ firstResolve: programRow });
+      const slotsBuilder = makeBuilder({ selfResolve: existingSlots });
+      const updateB1 = makeBuilder({ selfResolve: 1 });
+      const updateB2 = makeBuilder({ selfResolve: 1 });
+      const [programBuilder, exercisesBuilder] = buildProgramBuilders();
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(slotsBuilder)
+        .mockReturnValueOnce(updateB1)
+        .mockReturnValueOnce(updateB2)
+        .mockReturnValueOnce(programBuilder)
+        .mockReturnValueOnce(exercisesBuilder);
+
+      const result = await service.reorderExercises(trainerId, programId, {
+        exercises: [
+          { id: 'pe-a', order_index: 1 },
+          { id: 'pe-b', order_index: 0 },
+        ],
+      });
+
+      expect(result.id).toBe(programId);
+    });
+
+    it('should throw BadRequestException when exercise list is incomplete', async () => {
+      const existingSlots = [{ id: 'pe-a' }, { id: 'pe-b' }, { id: 'pe-c' }];
+
+      mockDb
+        .mockReturnValueOnce(makeBuilder({ firstResolve: programRow }))
+        .mockReturnValueOnce(makeBuilder({ selfResolve: existingSlots }));
+
+      await expect(
+        service.reorderExercises(trainerId, programId, {
+          exercises: [
+            { id: 'pe-a', order_index: 0 },
+            { id: 'pe-b', order_index: 1 },
+          ],
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw ForbiddenException when program is COMPLETE', async () => {
+      mockDb.mockReturnValueOnce(
+        makeBuilder({ firstResolve: { ...programRow, status: 'COMPLETE' } }),
+      );
+
+      await expect(
+        service.reorderExercises(trainerId, programId, { exercises: [] }),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // exportProgram
+  // ---------------------------------------------------------------------------
+  describe('exportProgram', () => {
+    it('should return a PDF buffer for a READY program', async () => {
+      const findBuilder = makeBuilder({ firstResolve: { ...programRow, status: 'READY' } });
+      const [programBuilder, exercisesBuilder] = buildProgramBuilders(
+        [],
+        { ...programWithClientName, status: 'READY' },
+      );
+
+      mockDb
+        .mockReturnValueOnce(findBuilder)
+        .mockReturnValueOnce(programBuilder)
+        .mockReturnValueOnce(exercisesBuilder);
+
+      const result = await service.exportProgram(trainerId, programId);
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+    });
+
+    it('should throw ForbiddenException when program status is not READY', async () => {
+      mockDb.mockReturnValueOnce(makeBuilder({ firstResolve: programRow }));
+
+      await expect(service.exportProgram(trainerId, programId)).rejects.toThrow(ForbiddenException);
+    });
+  });
+});

--- a/src/program/services/program.service.ts
+++ b/src/program/services/program.service.ts
@@ -1,0 +1,564 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import PDFDocument from 'pdfkit';
+import { KnexService } from '../../infra/database/knex.service';
+import {
+  ProgramEntity,
+  ProgramExerciseEntity,
+  ProgramStatus,
+} from 'src/types/db/program';
+import {
+  AddExerciseDto,
+  CreateProgramDto,
+  ProgramDto,
+  ProgramExerciseDto,
+  ProgramSummaryDto,
+  ReorderExercisesDto,
+  UpdateProgramDto,
+  UpdateProgramExerciseDto,
+} from 'src/types/dto/program.dto';
+
+interface ProgramExerciseRow extends ProgramExerciseEntity {
+  exercise_name: string;
+  exercise_demo: string | null;
+  tags: string[];
+}
+
+interface ProgramSummaryRow extends ProgramEntity {
+  client_name: string;
+  exercise_count: string;
+}
+
+const ALLOWED_TRANSITIONS: Record<ProgramStatus, ProgramStatus[]> = {
+  DRAFT: ['READY'],
+  READY: ['IN_PROGRESS', 'DRAFT'],
+  IN_PROGRESS: ['COMPLETE', 'DRAFT'],
+  COMPLETE: [],
+};
+
+@Injectable()
+export class ProgramService {
+  private readonly logger = new Logger(ProgramService.name);
+
+  constructor(private readonly knexService: KnexService) {}
+
+  private async findProgramOrThrow(
+    programId: string,
+    trainerId: string,
+  ): Promise<ProgramEntity> {
+    const program: ProgramEntity | undefined = await this.knexService
+      .db('programs')
+      .where('id', programId)
+      .first();
+
+    if (!program) {
+      this.logger.warn(`Program ${programId} not found`);
+      throw new NotFoundException(`Program ${programId} not found`);
+    }
+
+    if (program.trainer_id !== trainerId) {
+      this.logger.warn(
+        `Trainer ${trainerId} attempted to access program ${programId} owned by ${program.trainer_id}`,
+      );
+      throw new ForbiddenException('You do not have access to this program');
+    }
+
+    return program;
+  }
+
+  private async buildProgramResponse(programId: string): Promise<ProgramDto> {
+    const program: (ProgramEntity & { client_name: string }) | undefined =
+      await this.knexService
+        .db('programs as p')
+        .join('clients as c', 'p.client_id', 'c.id')
+        .join('users as u', 'c.client_id', 'u.id')
+        .select(
+          'p.id',
+          'p.trainer_id',
+          'p.client_id',
+          'p.name',
+          'p.description',
+          'p.status',
+          'p.tags',
+          'p.notes',
+          'p.created_at',
+          'p.updated_at',
+          this.knexService.db.raw(
+            "CONCAT(u.first_name, ' ', u.last_name) as client_name",
+          ),
+        )
+        .where('p.id', programId)
+        .first();
+
+    if (!program) {
+      throw new NotFoundException(`Program ${programId} not found`);
+    }
+
+    const exercises: ProgramExerciseRow[] = await this.knexService
+      .db('program_exercises as pe')
+      .join('exercises as e', 'pe.exercise_id', 'e.id')
+      .select(
+        'pe.id',
+        'pe.program_id',
+        'pe.exercise_id',
+        'pe.order_index',
+        'pe.sets',
+        'pe.reps',
+        'pe.duration_seconds',
+        'pe.notes',
+        'e.name as exercise_name',
+        'e.exercise_demo',
+        'e.tags',
+      )
+      .where('pe.program_id', programId)
+      .orderBy('pe.order_index', 'asc');
+
+    return {
+      id: program.id,
+      name: program.name,
+      description: program.description,
+      status: program.status,
+      tags: program.tags ?? [],
+      client_id: program.client_id,
+      client_name: program.client_name,
+      notes: program.notes,
+      exercises: exercises.map((pe) => this.toProgramExerciseDto(pe)),
+      created_at: program.created_at.toISOString(),
+      updated_at: program.updated_at.toISOString(),
+    };
+  }
+
+  private toProgramExerciseDto(pe: ProgramExerciseRow): ProgramExerciseDto {
+    return {
+      id: pe.id,
+      exercise_id: pe.exercise_id,
+      exercise_name: pe.exercise_name,
+      exercise_demo: pe.exercise_demo,
+      tags: pe.tags ?? [],
+      order_index: pe.order_index,
+      sets: pe.sets,
+      reps: pe.reps,
+      duration_seconds: pe.duration_seconds,
+      notes: pe.notes,
+    };
+  }
+
+  async getPrograms(
+    trainerId: string,
+    clientId?: string,
+  ): Promise<ProgramSummaryDto[]> {
+    this.logger.debug(`Fetching programs for trainer ${trainerId}`);
+
+    const query = this.knexService
+      .db('programs as p')
+      .join('clients as c', 'p.client_id', 'c.id')
+      .join('users as u', 'c.client_id', 'u.id')
+      .leftJoin('program_exercises as pe', 'pe.program_id', 'p.id')
+      .select(
+        'p.id',
+        'p.name',
+        'p.description',
+        'p.status',
+        'p.tags',
+        'p.client_id',
+        'p.created_at',
+        'p.updated_at',
+        this.knexService.db.raw(
+          "CONCAT(u.first_name, ' ', u.last_name) as client_name",
+        ),
+        this.knexService.db.raw('COUNT(pe.id)::integer as exercise_count'),
+      )
+      .where('p.trainer_id', trainerId)
+      .groupBy('p.id', 'p.tags', 'u.first_name', 'u.last_name')
+      .orderBy('p.created_at', 'desc');
+
+    if (clientId) {
+      query.where('p.client_id', clientId);
+    }
+
+    const rows: ProgramSummaryRow[] = await query;
+
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      description: r.description,
+      status: r.status,
+      tags: r.tags ?? [],
+      client_id: r.client_id,
+      client_name: r.client_name,
+      exercise_count: Number(r.exercise_count),
+      created_at: r.created_at.toISOString(),
+      updated_at: r.updated_at.toISOString(),
+    }));
+  }
+
+  async createProgram(
+    trainerId: string,
+    dto: CreateProgramDto,
+  ): Promise<ProgramDto> {
+    this.logger.debug(
+      `Creating program "${dto.name}" for trainer ${trainerId}`,
+    );
+
+    const client = await this.knexService
+      .db('clients')
+      .where('id', dto.client_id)
+      .where('trainer_id', trainerId)
+      .first();
+
+    if (!client) {
+      this.logger.warn(
+        `Client ${dto.client_id} not found or does not belong to trainer ${trainerId}`,
+      );
+      throw new ForbiddenException('Client does not belong to you');
+    }
+
+    const [{ id }] = await this.knexService
+      .db('programs')
+      .insert({
+        trainer_id: trainerId,
+        client_id: dto.client_id,
+        name: dto.name,
+        description: dto.description ?? null,
+        status: 'DRAFT',
+        tags: JSON.stringify(dto.tags ?? []),
+      })
+      .returning('id');
+
+    return this.buildProgramResponse(id);
+  }
+
+  async getProgramById(
+    trainerId: string,
+    programId: string,
+  ): Promise<ProgramDto> {
+    this.logger.debug(`Fetching program ${programId} for trainer ${trainerId}`);
+    await this.findProgramOrThrow(programId, trainerId);
+    return this.buildProgramResponse(programId);
+  }
+
+  async updateProgram(
+    trainerId: string,
+    programId: string,
+    dto: UpdateProgramDto,
+  ): Promise<ProgramDto> {
+    this.logger.debug(`Updating program ${programId}`);
+
+    const program = await this.findProgramOrThrow(programId, trainerId);
+
+    if (program.status === 'COMPLETE') {
+      throw new ForbiddenException('COMPLETE programs are immutable');
+    }
+
+    if (dto.status !== undefined) {
+      const allowed = ALLOWED_TRANSITIONS[program.status];
+      if (!allowed.includes(dto.status)) {
+        throw new BadRequestException(
+          `Invalid status transition: ${program.status} → ${dto.status}`,
+        );
+      }
+    }
+
+    const updatePayload: Partial<ProgramEntity> = { updated_at: new Date() };
+    if (dto.name !== undefined) updatePayload.name = dto.name;
+    if (dto.description !== undefined)
+      updatePayload.description = dto.description;
+    if (dto.status !== undefined) updatePayload.status = dto.status;
+    if (dto.tags !== undefined) updatePayload.tags = dto.tags;
+    if (dto.notes !== undefined) updatePayload.notes = dto.notes;
+
+    await this.knexService
+      .db('programs')
+      .where('id', programId)
+      .update(updatePayload);
+
+    return this.buildProgramResponse(programId);
+  }
+
+  async deleteProgram(trainerId: string, programId: string): Promise<void> {
+    this.logger.debug(`Deleting program ${programId}`);
+    await this.findProgramOrThrow(programId, trainerId);
+    await this.knexService.db('programs').where('id', programId).del();
+  }
+
+  async addExercise(
+    trainerId: string,
+    programId: string,
+    dto: AddExerciseDto,
+  ): Promise<ProgramExerciseDto> {
+    this.logger.debug(
+      `Adding exercise ${dto.exercise_id} to program ${programId}`,
+    );
+
+    const program = await this.findProgramOrThrow(programId, trainerId);
+
+    if (program.status === 'COMPLETE') {
+      throw new ForbiddenException('COMPLETE programs are immutable');
+    }
+
+    const exercise = await this.knexService
+      .db('exercises')
+      .where('id', dto.exercise_id)
+      .first();
+
+    if (!exercise) {
+      throw new NotFoundException(`Exercise ${dto.exercise_id} not found`);
+    }
+
+    if (exercise.trainer_id !== trainerId) {
+      throw new ForbiddenException('Exercise does not belong to you');
+    }
+
+    const maxRow = await this.knexService
+      .db('program_exercises')
+      .where('program_id', programId)
+      .max('order_index as max_index')
+      .first();
+
+    const nextIndex =
+      maxRow?.max_index != null ? Number(maxRow.max_index) + 1 : 0;
+
+    const [inserted]: ProgramExerciseEntity[] = await this.knexService
+      .db('program_exercises')
+      .insert({
+        program_id: programId,
+        exercise_id: dto.exercise_id,
+        order_index: nextIndex,
+        sets: dto.sets ?? null,
+        reps: dto.reps ?? null,
+        duration_seconds: dto.duration_seconds ?? null,
+        notes: dto.notes ?? null,
+      })
+      .returning('*');
+
+    return {
+      id: inserted.id,
+      exercise_id: inserted.exercise_id,
+      exercise_name: exercise.name,
+      exercise_demo: exercise.exercise_demo ?? null,
+      tags: exercise.tags ?? [],
+      order_index: inserted.order_index,
+      sets: inserted.sets,
+      reps: inserted.reps,
+      duration_seconds: inserted.duration_seconds,
+      notes: inserted.notes,
+    };
+  }
+
+  async updateProgramExercise(
+    trainerId: string,
+    programId: string,
+    programExerciseId: string,
+    dto: UpdateProgramExerciseDto,
+  ): Promise<ProgramExerciseDto> {
+    this.logger.debug(
+      `Updating program_exercise ${programExerciseId} in program ${programId}`,
+    );
+
+    const program = await this.findProgramOrThrow(programId, trainerId);
+
+    if (program.status === 'COMPLETE') {
+      throw new ForbiddenException('COMPLETE programs are immutable');
+    }
+
+    const slot: ProgramExerciseEntity | undefined = await this.knexService
+      .db('program_exercises')
+      .where('id', programExerciseId)
+      .where('program_id', programId)
+      .first();
+
+    if (!slot) {
+      throw new NotFoundException(
+        `Exercise slot ${programExerciseId} not found in program ${programId}`,
+      );
+    }
+
+    const updatePayload: Partial<ProgramExerciseEntity> = {};
+    if (dto.sets !== undefined) updatePayload.sets = dto.sets;
+    if (dto.reps !== undefined) updatePayload.reps = dto.reps;
+    if (dto.duration_seconds !== undefined)
+      updatePayload.duration_seconds = dto.duration_seconds;
+    if (dto.notes !== undefined) updatePayload.notes = dto.notes;
+
+    const [updated]: ProgramExerciseEntity[] = await this.knexService
+      .db('program_exercises')
+      .where('id', programExerciseId)
+      .update(updatePayload)
+      .returning('*');
+
+    const exercise = await this.knexService
+      .db('exercises')
+      .where('id', updated.exercise_id)
+      .select('name', 'exercise_demo', 'tags')
+      .first();
+
+    return {
+      id: updated.id,
+      exercise_id: updated.exercise_id,
+      exercise_name: exercise.name,
+      exercise_demo: exercise.exercise_demo ?? null,
+      tags: exercise.tags ?? [],
+      order_index: updated.order_index,
+      sets: updated.sets,
+      reps: updated.reps,
+      duration_seconds: updated.duration_seconds,
+      notes: updated.notes,
+    };
+  }
+
+  async removeProgramExercise(
+    trainerId: string,
+    programId: string,
+    programExerciseId: string,
+  ): Promise<void> {
+    this.logger.debug(
+      `Removing program_exercise ${programExerciseId} from program ${programId}`,
+    );
+
+    const program = await this.findProgramOrThrow(programId, trainerId);
+
+    if (program.status === 'COMPLETE') {
+      throw new ForbiddenException('COMPLETE programs are immutable');
+    }
+
+    const slot: ProgramExerciseEntity | undefined = await this.knexService
+      .db('program_exercises')
+      .where('id', programExerciseId)
+      .where('program_id', programId)
+      .first();
+
+    if (!slot) {
+      throw new NotFoundException(
+        `Exercise slot ${programExerciseId} not found in program ${programId}`,
+      );
+    }
+
+    await this.knexService
+      .db('program_exercises')
+      .where('id', programExerciseId)
+      .del();
+
+    const remaining: ProgramExerciseEntity[] = await this.knexService
+      .db('program_exercises')
+      .where('program_id', programId)
+      .orderBy('order_index', 'asc')
+      .select('id');
+
+    await Promise.all(
+      remaining.map((pe, index) =>
+        this.knexService
+          .db('program_exercises')
+          .where('id', pe.id)
+          .update({ order_index: index }),
+      ),
+    );
+  }
+
+  async reorderExercises(
+    trainerId: string,
+    programId: string,
+    dto: ReorderExercisesDto,
+  ): Promise<ProgramDto> {
+    this.logger.debug(`Reordering exercises in program ${programId}`);
+
+    const program = await this.findProgramOrThrow(programId, trainerId);
+
+    if (program.status === 'COMPLETE') {
+      throw new ForbiddenException('COMPLETE programs are immutable');
+    }
+
+    const existingSlots: { id: string }[] = await this.knexService
+      .db('program_exercises')
+      .where('program_id', programId)
+      .select('id');
+
+    const existingIds = new Set(existingSlots.map((s) => s.id));
+    const providedIds = new Set(dto.exercises.map((e) => e.id));
+
+    for (const id of existingIds) {
+      if (!providedIds.has(id)) {
+        throw new BadRequestException(
+          'Reorder payload is missing existing exercise IDs',
+        );
+      }
+    }
+
+    await Promise.all(
+      dto.exercises.map((e) =>
+        this.knexService
+          .db('program_exercises')
+          .where('id', e.id)
+          .where('program_id', programId)
+          .update({ order_index: e.order_index }),
+      ),
+    );
+
+    return this.buildProgramResponse(programId);
+  }
+
+  async exportProgram(trainerId: string, programId: string): Promise<Buffer> {
+    this.logger.debug(`Exporting program ${programId} as PDF`);
+
+    const program = await this.findProgramOrThrow(programId, trainerId);
+
+    if (program.status !== 'READY') {
+      throw new ForbiddenException('Only READY programs can be exported');
+    }
+
+    const full = await this.buildProgramResponse(programId);
+
+    return new Promise((resolve, reject) => {
+      const doc = new PDFDocument({ margin: 50 });
+      const chunks: Buffer[] = [];
+
+      doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+      doc.on('end', () => resolve(Buffer.concat(chunks)));
+      doc.on('error', reject);
+
+      doc.fontSize(20).text(full.name, { underline: true });
+      doc.moveDown(0.5);
+      doc.fontSize(12).text(`Client: ${full.client_name}`);
+      doc.text(`Status: ${full.status}`);
+      if (full.tags.length > 0) {
+        doc.text(`Tags: ${full.tags.join(', ')}`);
+      }
+      if (full.description) {
+        doc.moveDown(0.5);
+        doc.text(`Description: ${full.description}`);
+      }
+      if (full.notes) {
+        doc.moveDown(0.5);
+        doc.text(`Notes: ${full.notes}`);
+      }
+
+      if (full.exercises.length > 0) {
+        doc.moveDown(1);
+        doc.fontSize(16).text('Exercises', { underline: true });
+        doc.moveDown(0.5);
+
+        full.exercises.forEach((ex, i) => {
+          doc.fontSize(13).text(`${i + 1}. ${ex.exercise_name}`);
+          const details: string[] = [];
+          if (ex.sets != null) details.push(`Sets: ${ex.sets}`);
+          if (ex.reps) details.push(`Reps: ${ex.reps}`);
+          if (ex.duration_seconds != null)
+            details.push(`Duration: ${ex.duration_seconds}s`);
+          if (details.length > 0) {
+            doc.fontSize(11).text(`   ${details.join(' | ')}`);
+          }
+          if (ex.notes) {
+            doc.fontSize(11).text(`   Notes: ${ex.notes}`);
+          }
+          doc.moveDown(0.3);
+        });
+      }
+
+      doc.end();
+    });
+  }
+}

--- a/src/types/db/program.ts
+++ b/src/types/db/program.ts
@@ -1,7 +1,25 @@
-export type Program = {
+export type ProgramStatus = 'DRAFT' | 'READY' | 'IN_PROGRESS' | 'COMPLETE';
+
+export interface ProgramEntity {
   id: string;
+  trainer_id: string;
   client_id: string;
-  status: string;
-  workout: any;
+  name: string;
+  description: string | null;
+  status: ProgramStatus;
   tags: string[];
-};
+  notes: string | null;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface ProgramExerciseEntity {
+  id: string;
+  program_id: string;
+  exercise_id: string;
+  order_index: number;
+  sets: number | null;
+  reps: string | null;
+  duration_seconds: number | null;
+  notes: string | null;
+}

--- a/src/types/dto/program.dto.ts
+++ b/src/types/dto/program.dto.ts
@@ -1,0 +1,241 @@
+import {
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export type ProgramStatus = 'DRAFT' | 'READY' | 'IN_PROGRESS' | 'COMPLETE';
+
+const ProgramStatusEnum = ['DRAFT', 'READY', 'IN_PROGRESS', 'COMPLETE'];
+
+export class ProgramExerciseDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  exercise_id: string;
+
+  @ApiProperty()
+  exercise_name: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  exercise_demo: string | null;
+
+  @ApiProperty({ type: [String] })
+  tags: string[];
+
+  @ApiProperty()
+  order_index: number;
+
+  @ApiPropertyOptional({ nullable: true })
+  sets: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  reps: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  duration_seconds: number | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  notes: string | null;
+}
+
+export class ProgramSummaryDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  description: string | null;
+
+  @ApiProperty({ enum: ProgramStatusEnum })
+  status: ProgramStatus;
+
+  @ApiProperty({ type: [String] })
+  tags: string[];
+
+  @ApiProperty()
+  client_id: string;
+
+  @ApiProperty()
+  client_name: string;
+
+  @ApiProperty()
+  exercise_count: number;
+
+  @ApiProperty()
+  created_at: string;
+
+  @ApiProperty()
+  updated_at: string;
+}
+
+export class ProgramDto {
+  @ApiProperty()
+  id: string;
+
+  @ApiProperty()
+  name: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  description: string | null;
+
+  @ApiProperty({ enum: ProgramStatusEnum })
+  status: ProgramStatus;
+
+  @ApiProperty({ type: [String] })
+  tags: string[];
+
+  @ApiProperty()
+  client_id: string;
+
+  @ApiProperty()
+  client_name: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  notes: string | null;
+
+  @ApiProperty({ type: [ProgramExerciseDto] })
+  exercises: ProgramExerciseDto[];
+
+  @ApiProperty()
+  created_at: string;
+
+  @ApiProperty()
+  updated_at: string;
+}
+
+export class GetProgramsQueryDto {
+  @ApiPropertyOptional({ description: 'Filter programs by client UUID' })
+  @IsUUID()
+  @IsOptional()
+  client_id?: string;
+}
+
+export class CreateProgramDto {
+  @ApiProperty()
+  @IsUUID()
+  @IsNotEmpty()
+  client_id: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiPropertyOptional({ type: [String], description: 'Program focus tags' })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  tags?: string[];
+}
+
+export class UpdateProgramDto {
+  @ApiPropertyOptional()
+  @IsString()
+  @IsNotEmpty()
+  @IsOptional()
+  name?: string;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @ApiPropertyOptional({ enum: ProgramStatusEnum })
+  @IsEnum(ProgramStatusEnum)
+  @IsOptional()
+  status?: ProgramStatus;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  notes?: string;
+
+  @ApiPropertyOptional({ type: [String], description: 'Replaces the entire tags array' })
+  @IsArray()
+  @IsString({ each: true })
+  @IsOptional()
+  tags?: string[];
+}
+
+export class AddExerciseDto {
+  @ApiProperty()
+  @IsUUID()
+  @IsNotEmpty()
+  exercise_id: string;
+
+  @ApiPropertyOptional()
+  @IsInt()
+  @IsOptional()
+  sets?: number;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  reps?: string;
+
+  @ApiPropertyOptional()
+  @IsInt()
+  @IsOptional()
+  duration_seconds?: number;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}
+
+export class UpdateProgramExerciseDto {
+  @ApiPropertyOptional()
+  @IsInt()
+  @IsOptional()
+  sets?: number;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  reps?: string;
+
+  @ApiPropertyOptional()
+  @IsInt()
+  @IsOptional()
+  duration_seconds?: number;
+
+  @ApiPropertyOptional()
+  @IsString()
+  @IsOptional()
+  notes?: string;
+}
+
+export class ReorderItemDto {
+  @ApiProperty()
+  @IsUUID()
+  id: string;
+
+  @ApiProperty()
+  @IsInt()
+  order_index: number;
+}
+
+export class ReorderExercisesDto {
+  @ApiProperty({ type: [ReorderItemDto] })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ReorderItemDto)
+  exercises: ReorderItemDto[];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,7 +1038,12 @@
   dependencies:
     tslib "2.8.1"
 
-"@noble/hashes@^1.1.5":
+"@noble/ciphers@^1.0.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/ciphers/-/ciphers-1.3.0.tgz#f64b8ff886c240e644e5573c097f86e5b43676dc"
+  integrity sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==
+
+"@noble/hashes@^1.1.5", "@noble/hashes@^1.6.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
@@ -1193,6 +1198,13 @@
     "@supabase/postgrest-js" "1.19.4"
     "@supabase/realtime-js" "2.11.15"
     "@supabase/storage-js" "^2.10.4"
+
+"@swc/helpers@^0.5.12":
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.21.tgz#0b1b020317ee1282860ca66f7e9a7c7790f05ae0"
+  integrity sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==
+  dependencies:
+    tslib "^2.8.0"
 
 "@tokenizer/inflate@^0.2.7":
   version "0.2.7"
@@ -1404,6 +1416,13 @@
   integrity sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==
   dependencies:
     undici-types "~7.8.0"
+
+"@types/pdfkit@^0.17.6":
+  version "0.17.6"
+  resolved "https://registry.yarnpkg.com/@types/pdfkit/-/pdfkit-0.17.6.tgz#b0a4b728b1d0bfb7ec6e574efebba7dc6bf4cca1"
+  integrity sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==
+  dependencies:
+    "@types/node" "*"
 
 "@types/phoenix@^1.6.6":
   version "1.6.6"
@@ -2060,7 +2079,12 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.3.1:
+base64-js@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
+  integrity sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==
+
+base64-js@^1.1.2, base64-js@^1.3.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -2110,6 +2134,20 @@ braces@^3.0.3:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
+
+brotli@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/brotli/-/brotli-1.3.3.tgz#7365d8cc00f12cf765d2b2c898716bcf4b604d48"
+  integrity sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==
+  dependencies:
+    base64-js "^1.1.2"
+
+browserify-zlib@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
+  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
+  dependencies:
+    pako "~1.0.5"
 
 browserslist@^4.24.0:
   version "4.25.1"
@@ -2294,6 +2332,11 @@ clone@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==
+
+clone@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
 
 co@^4.6.0:
   version "4.6.0"
@@ -2507,6 +2550,11 @@ dezalgo@^1.0.4:
   dependencies:
     asap "^2.0.0"
     wrappy "1"
+
+dfa@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/dfa/-/dfa-1.2.0.tgz#96ac3204e2d29c49ea5b57af8d92c2ae12790657"
+  integrity sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -2998,6 +3046,21 @@ flatted@^3.2.9:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+
+fontkit@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/fontkit/-/fontkit-2.0.4.tgz#4765d664c68b49b5d6feb6bd1051ee49d8ec5ab0"
+  integrity sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==
+  dependencies:
+    "@swc/helpers" "^0.5.12"
+    brotli "^1.3.2"
+    clone "^2.1.2"
+    dfa "^1.2.0"
+    fast-deep-equal "^3.1.3"
+    restructure "^3.0.0"
+    tiny-inflate "^1.0.3"
+    unicode-properties "^1.4.0"
+    unicode-trie "^2.0.0"
 
 foreground-child@^3.1.0, foreground-child@^3.3.1:
   version "3.3.1"
@@ -3854,6 +3917,11 @@ joi@^17.13.3:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
+js-md5@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.8.3.tgz#921bab7efa95bfc9d62b87ee08a57f8fe4305b69"
+  integrity sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4007,6 +4075,14 @@ libphonenumber-js@^1.11.1:
   version "1.12.15"
   resolved "https://registry.yarnpkg.com/libphonenumber-js/-/libphonenumber-js-1.12.15.tgz#548da03454e94f2fa445fe4fc9fd70c44c0ce16b"
   integrity sha512-TMDCtIhWUDHh91wRC+wFuGlIzKdPzaTUHHVrIZ3vPUEoNaXFLrsIQ1ZpAeZeXApIF6rvDksMTvjrIQlLKaYxqQ==
+
+linebreak@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/linebreak/-/linebreak-1.1.0.tgz#831cf378d98bced381d8ab118f852bd50d81e46b"
+  integrity sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==
+  dependencies:
+    base64-js "0.0.8"
+    unicode-trie "^2.0.0"
 
 lines-and-columns@^1.1.6:
   version "1.2.4"
@@ -4455,6 +4531,16 @@ package-json-from-dist@^1.0.0:
   resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz#4f1471a010827a86f94cfd9b0727e36d267de505"
   integrity sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==
 
+pako@^0.2.5:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
+  integrity sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==
+
+pako@~1.0.5:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -4555,6 +4641,18 @@ pause@0.0.1:
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.0.1.tgz#1d408b3fdb76923b9543d96fb4c9dfd535d9cb5d"
   integrity sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==
 
+pdfkit@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/pdfkit/-/pdfkit-0.18.0.tgz#573efa7f4c78a8ab1362232a05a589b97b292216"
+  integrity sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==
+  dependencies:
+    "@noble/ciphers" "^1.0.0"
+    "@noble/hashes" "^1.6.0"
+    fontkit "^2.0.4"
+    js-md5 "^0.8.3"
+    linebreak "^1.1.0"
+    png-js "^1.0.0"
+
 pg-cloudflare@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz#a1f3d226bab2c45ae75ea54d65ec05ac6cfafbef"
@@ -4652,6 +4750,13 @@ pluralize@8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
+
+png-js@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/png-js/-/png-js-1.1.0.tgz#60a135216601f807b88a6d61ac93bd42a32c5ee1"
+  integrity sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==
+  dependencies:
+    browserify-zlib "^0.2.0"
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -4832,6 +4937,11 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+restructure@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/restructure/-/restructure-3.0.2.tgz#e6b2fad214f78edee21797fa8160fef50eb9b49a"
+  integrity sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==
 
 reusify@^1.0.4:
   version "1.1.0"
@@ -5274,6 +5384,11 @@ tildify@2.0.0:
   resolved "https://registry.yarnpkg.com/tildify/-/tildify-2.0.0.tgz#f205f3674d677ce698b7067a99e949ce03b4754a"
   integrity sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==
 
+tiny-inflate@^1.0.0, tiny-inflate@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
+  integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -5385,7 +5500,7 @@ tsconfig-paths@4.2.0, tsconfig-paths@^4.1.2, tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@2.8.1, tslib@^2.1.0, tslib@^2.4.0:
+tslib@2.8.1, tslib@^2.1.0, tslib@^2.4.0, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
@@ -5470,6 +5585,22 @@ undici-types@~7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
   integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
+
+unicode-properties@^1.4.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/unicode-properties/-/unicode-properties-1.4.1.tgz#96a9cffb7e619a0dc7368c28da27e05fc8f9be5f"
+  integrity sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==
+  dependencies:
+    base64-js "^1.3.0"
+    unicode-trie "^2.0.0"
+
+unicode-trie@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-trie/-/unicode-trie-2.0.0.tgz#8fd8845696e2e14a8b67d78fa9e0dd2cad62fec8"
+  integrity sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==
+  dependencies:
+    pako "^0.2.5"
+    tiny-inflate "^1.0.0"
 
 universalify@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Summary
- Adds full `ProgramModule` with CRUD endpoints for programs and exercise management (add, update, remove, reorder)
- Includes status machine transitions (DRAFT → READY → IN_PROGRESS → COMPLETE) and PDF export for READY programs
- Adds 3 migrations: `programs`, `program_exercises` tables, and `tags` column; fixes `clients → users` join to use `client_id` FK

## Test plan
- [ ] `GET /programs` returns empty array for new trainer
- [ ] `POST /programs` creates a program in DRAFT status
- [ ] `GET /programs/:id` returns program with exercises
- [ ] `PATCH /programs/:id` updates fields and enforces status transitions
- [ ] `POST /programs/:id/exercises` adds an exercise
- [ ] `PATCH /programs/:id/exercises/reorder` reorders exercises
- [ ] `PATCH /programs/:id/exercises/:peId` updates exercise slot
- [ ] `DELETE /programs/:id/exercises/:peId` removes and reindexes remaining
- [ ] `GET /programs/:id/export` returns PDF for READY programs
- [ ] `DELETE /programs/:id` deletes program and cascades to exercises
- [ ] Run `yarn migrate:latest` before testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)