### PR TITLE
fix: normalize JWT user id from Supabase sub claim

### DIFF
--- a/src/auth/strategies/supabase.strategy.ts
+++ b/src/auth/strategies/supabase.strategy.ts
@@ -14,10 +14,6 @@ export class SupabaseStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any): Promise<any> {
-    return payload;
-  }
-
-  authenticate(req) {
-    super.authenticate(req);
+    return { ...payload, id: payload.id ?? payload.sub };
   }
 }


### PR DESCRIPTION
## Summary
- `SupabaseStrategy.validate` now returns `{ ...payload, id: payload.id ?? payload.sub }` so `req.user.id` is always populated regardless of whether the token was issued by Supabase (uses `sub`) or generated locally via `generateToken` (uses `id`)
- Removes the redundant `authenticate()` override that was a no-op

## Root cause
Supabase-issued JWTs carry the user UUID under the `sub` claim, not `id`. Any guarded endpoint reading `req.user.id` — `POST /programs`, `GET /programs`, `GET /dashboard`, etc. — received `undefined` as the trainer ID, which caused the ownership check in `createProgram` to match no rows and throw a spurious 403 "Client does not belong to you".

## Test plan
- [ ] Generate a Supabase-issued JWT and call `POST /programs` — should no longer 403
- [ ] Verify `GET /dashboard` and other guarded endpoints still work with both token types
- [ ] Locally-generated tokens from `GET /user/:id/token` should be unaffected (`payload.id` takes precedence over `payload.sub`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)