### PR TITLE
feat: passwordless login via email OTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pdfkit": "^0.18.0",
     "pg": "^8.16.3",
     "reflect-metadata": "^0.2.2",
+    "resend": "^6.17.2",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, HttpCode, HttpStatus, Post } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { AuthService } from './services/auth.service';
+import { RequestOtpDto, VerifyOtpDto } from './dto/auth.dto';
+
+@ApiTags('Auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @ApiOperation({ summary: 'Send a one-time login code to a coach or admin email' })
+  @Post('request-otp')
+  @HttpCode(HttpStatus.OK)
+  requestOtp(@Body() dto: RequestOtpDto) {
+    return this.authService.requestOtp(dto);
+  }
+
+  @ApiOperation({ summary: 'Verify the login code and receive an access token' })
+  @Post('verify-otp')
+  @HttpCode(HttpStatus.OK)
+  verifyOtp(@Body() dto: VerifyOtpDto) {
+    return this.authService.verifyOtp(dto);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -4,6 +4,8 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { JwtAuthGuard } from './guards/jwt.auth.guard';
 import { SupabaseStrategy } from './strategies/supabase.strategy';
+import { AuthController } from './auth.controller';
+import { AuthService } from './services/auth.service';
 
 @Module({
   imports: [
@@ -20,7 +22,8 @@ import { SupabaseStrategy } from './strategies/supabase.strategy';
       inject: [ConfigService],
     }),
   ],
-  providers: [JwtAuthGuard, SupabaseStrategy],
+  controllers: [AuthController],
+  providers: [JwtAuthGuard, SupabaseStrategy, AuthService],
   exports: [JwtAuthGuard, JwtModule],
 })
 export class AuthModule {}

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,0 +1,21 @@
+import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class RequestOtpDto {
+  @ApiProperty({ example: 'coach@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+}
+
+export class VerifyOtpDto {
+  @ApiProperty({ example: 'coach@example.com' })
+  @IsEmail()
+  @IsNotEmpty()
+  email: string;
+
+  @ApiProperty({ example: '123456' })
+  @IsString()
+  @IsNotEmpty()
+  token: string;
+}

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -1,0 +1,125 @@
+import {
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+  Logger,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { Resend } from 'resend';
+import { KnexService } from '../../infra/database/knex.service';
+import { SupabaseService } from '../../infra/supabase/supabase.service';
+import { User, UserRole } from '../../types/db/user';
+import { RequestOtpDto, VerifyOtpDto } from '../dto/auth.dto';
+
+@Injectable()
+export class AuthService {
+  private readonly logger = new Logger(AuthService.name);
+  private readonly resend = new Resend(process.env.RESEND_API_KEY);
+
+  constructor(
+    private readonly knexService: KnexService,
+    private readonly supabaseService: SupabaseService,
+    private readonly jwtService: JwtService,
+  ) {}
+
+  async requestOtp({ email }: RequestOtpDto): Promise<{ message: string }> {
+    const user = await this.knexService
+      .db('users')
+      .where({ email: email.toLowerCase() })
+      .first<User>();
+
+    if (!user) {
+      throw new NotFoundException('No account found with that email address');
+    }
+
+    if (user.role !== UserRole.ADMIN && user.role !== UserRole.COACH) {
+      throw new ForbiddenException('Access restricted to coaches and admins');
+    }
+
+    // Ensure the user exists in Supabase Auth as a confirmed account.
+    // createUser fails silently if they already exist — that's fine.
+    const { error: createError } =
+      await this.supabaseService.client.auth.admin.createUser({
+        email,
+        email_confirm: true,
+      });
+
+    if (createError) {
+      this.logger.warn(`Supabase createUser (may already exist): ${createError.message}`);
+    }
+
+    // generateLink gives us the 6-digit email_otp directly so we control the
+    // email instead of relying on Supabase's template rendering.
+    const { data: linkData, error: linkError } =
+      await this.supabaseService.client.auth.admin.generateLink({
+        type: 'magiclink',
+        email,
+      });
+
+    if (linkError || !linkData.properties?.email_otp) {
+      this.logger.error(`Supabase generateLink error: ${linkError?.message}`);
+      throw new InternalServerErrorException('Failed to generate login code');
+    }
+
+    const otp = linkData.properties.email_otp;
+
+    const { error: emailError } = await this.resend.emails.send({
+      from: process.env.RESEND_FROM_EMAIL!,
+      to: email,
+      subject: 'Your GetJahBodyRight login code',
+      html: `
+        <h2>Your login code</h2>
+        <p>Enter this code to sign in to GetJahBodyRight:</p>
+        <p style="font-size:32px;font-weight:bold;letter-spacing:8px;">${otp}</p>
+        <p>This code expires in 1 hour. Do not share it.</p>
+      `,
+    });
+
+    if (emailError) {
+      this.logger.error(`Resend email error: ${emailError.message}`);
+      throw new InternalServerErrorException('Failed to send login code');
+    }
+
+    return { message: 'Login code sent — check your email' };
+  }
+
+  async verifyOtp({
+    email,
+    token,
+  }: VerifyOtpDto): Promise<{ access_token: string; user: Partial<User> }> {
+    const { error } = await this.supabaseService.anonClient.auth.verifyOtp({
+      email,
+      token,
+      type: 'email',
+    });
+
+    if (error) {
+      this.logger.error(`Supabase verify OTP error: ${error.message}`);
+      throw new UnauthorizedException('Invalid or expired login code');
+    }
+
+    const user = await this.knexService
+      .db('users')
+      .where({ email: email.toLowerCase() })
+      .first<User>();
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const access_token = this.jwtService.sign({ id: user.id });
+
+    return {
+      access_token,
+      user: {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        first_name: user.first_name,
+        last_name: user.last_name,
+      },
+    };
+  }
+}

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -9,7 +9,10 @@ export const validate = (cfg: Record<string, unknown>) => {
     DATABASE_URL: Joi.string().required(),
     DIRECT_URL: Joi.string().optional(),
     SUPABASE_URL: Joi.string().uri().required(),
+    SUPABASE_ANON_KEY: Joi.string().required(),
     SUPABASE_SERVICE_ROLE_KEY: Joi.string().required(),
+    RESEND_API_KEY: Joi.string().required(),
+    RESEND_FROM_EMAIL: Joi.string().email().required(),
   }).unknown(true);
 
   const { error, value } = schema.validate(cfg);

--- a/src/infra/supabase/supabase.service.ts
+++ b/src/infra/supabase/supabase.service.ts
@@ -5,18 +5,34 @@ import { createClient, SupabaseClient } from '@supabase/supabase-js';
 export class SupabaseService implements OnModuleInit {
   private readonly logger = new Logger(SupabaseService.name);
   private _client!: SupabaseClient;
+  private _anonClient!: SupabaseClient;
 
+  /** Service-role client — for admin/DB operations, bypasses RLS */
   get client(): SupabaseClient {
     return this._client;
   }
 
+  /** Anon client — required for client-side auth flows (signInWithOtp, verifyOtp) */
+  get anonClient(): SupabaseClient {
+    return this._anonClient;
+  }
+
   onModuleInit() {
     const url = process.env.SUPABASE_URL;
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const anonKey = process.env.SUPABASE_ANON_KEY;
 
     this.logger.log(`SUPABASE_URL: ${url ?? 'UNDEFINED'}`);
-    this.logger.log(`SUPABASE_SERVICE_ROLE_KEY: ${key ? 'set' : 'UNDEFINED'}`);
+    this.logger.log(`SUPABASE_SERVICE_ROLE_KEY: ${serviceKey ? 'set' : 'UNDEFINED'}`);
+    this.logger.log(`SUPABASE_ANON_KEY: ${anonKey ? 'set' : 'UNDEFINED'}`);
 
-    this._client = createClient(url!, key!);
+    this._client = createClient(url!, serviceKey!);
+    this._anonClient = createClient(url!, anonKey!, {
+      auth: {
+        flowType: 'implicit',
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1134,6 +1134,11 @@
   dependencies:
     "@sinonjs/commons" "^3.0.1"
 
+"@stablelib/base64@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
+
 "@supabase/auth-js@2.71.1":
   version "2.71.1"
   resolved "https://registry.yarnpkg.com/@supabase/auth-js/-/auth-js-2.71.1.tgz#349802c3b8275d62437e755ba73bd0cd8c26cd93"
@@ -2951,6 +2956,11 @@ fast-safe-stringify@2.1.1, fast-safe-stringify@^2.1.1:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
   integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
+
 fast-uri@^3.0.1:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
@@ -4758,6 +4768,11 @@ png-js@^1.0.0:
   dependencies:
     browserify-zlib "^0.2.0"
 
+postal-mime@2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/postal-mime/-/postal-mime-2.7.4.tgz#3718d1f188357ed86f906f1db8d4ca455efa4927"
+  integrity sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==
+
 postgres-array@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/postgres-array/-/postgres-array-2.0.0.tgz#48f8fce054fbc69671999329b8834b772652d82e"
@@ -4903,6 +4918,14 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+resend@^6.17.2:
+  version "6.17.2"
+  resolved "https://registry.yarnpkg.com/resend/-/resend-6.17.2.tgz#d935dc7e602d4472baf25ed1169ad0de86a1e772"
+  integrity sha512-hbaXEORFIFfT2Bh03NsA/akTTTKkD1hiuJ88ke64c5dWVV6DyoLxzFve3OiZqVOQ+JKLJ5uVkPR6hlUslpJFoA==
+  dependencies:
+    postal-mime "2.7.4"
+    standardwebhooks "1.0.0"
 
 resolve-cwd@^3.0.0:
   version "3.0.0"
@@ -5172,6 +5195,14 @@ stack-utils@^2.0.6:
   integrity sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==
   dependencies:
     escape-string-regexp "^2.0.0"
+
+standardwebhooks@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz#5faa23ceacbf9accd344361101d9e3033b64324f"
+  integrity sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==
+  dependencies:
+    "@stablelib/base64" "^1.0.0"
+    fast-sha256 "^1.3.0"
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## Summary

- Adds `POST /auth/request-otp` — validates the email belongs to an Admin or Coach, ensures a confirmed Supabase Auth account exists, generates a 6-digit OTP via `admin.generateLink`, and sends a branded email via Resend
- Adds `POST /auth/verify-otp` — verifies the OTP with Supabase and returns an app JWT + user profile
- Adds a second Supabase client (anon key, implicit flow) alongside the existing service-role client so client-side auth calls are correctly routed
- Adds `RESEND_API_KEY` and `RESEND_FROM_EMAIL` env vars (+ `SUPABASE_ANON_KEY`) to config validation

## Test plan

- [ ] `POST /auth/request-otp` with a valid Admin/Coach email returns 200 and sends a 6-digit code email
- [ ] `POST /auth/request-otp` with an unknown email returns 404
- [ ] `POST /auth/request-otp` with a Client-role email returns 403
- [ ] `POST /auth/verify-otp` with the correct code returns `access_token` and user object
- [ ] `POST /auth/verify-otp` with a wrong or expired code returns 401
- [ ] The returned `access_token` grants access to a protected endpoint (e.g. `GET /user/dashboard`)
- [ ] Add `SUPABASE_ANON_KEY`, `RESEND_API_KEY`, `RESEND_FROM_EMAIL` to production secrets before deploying

🤖 Generated with [Claude Code](https://claude.com/claude-code)